### PR TITLE
fix: handle bolds and italics with underscores

### DIFF
--- a/src/commonMain/kotlin/ch/derlin/bitdowntoc/AnchorGenerator.kt
+++ b/src/commonMain/kotlin/ch/derlin/bitdowntoc/AnchorGenerator.kt
@@ -28,6 +28,8 @@ object DefaultAnchorGenerator : AnchorGenerator {
             .lowercase()
             // text in `` is sanitized (no special chars), but the text is kept
             .transformInlineCode { it.stripNonLatinCharacters() }
+            // Remove italic and bold using '_' instead of '*'
+            .removeUnderscoreBoldAndItalics()
             // other HTML tags <*> are removed
             .stripHtmlTags()
             // for markdown links [a](b), only the text "a" part is kept
@@ -134,3 +136,11 @@ internal fun String.stripMarkdownLinks() =
 private val concatRegex = Regex("--+")
 internal fun String.concatSpaces() =
     replace(concatRegex, "-")
+
+private val underscoreBoldAndItalicsRegexes = listOf("__", "_").map {
+    Regex("\\b$it([^_\\s]|[^_\\s].*?[^_\\s])$it\\b")
+}
+internal fun String.removeUnderscoreBoldAndItalics() =
+    underscoreBoldAndItalicsRegexes.fold(this) { s, regex ->
+        s.replace(regex, "$1")
+    }

--- a/src/commonTest/kotlin/ch.derlin.bitdowntoc/AnchorsGeneratorTest.kt
+++ b/src/commonTest/kotlin/ch.derlin.bitdowntoc/AnchorsGeneratorTest.kt
@@ -8,6 +8,20 @@ import kotlin.test.assertEquals
 class AnchorsGeneratorTest {
 
     @Test
+    fun testRemoveBoldsAndItalics() {
+        mapOf(
+            "__hello__ _world_" to "hello world",
+            "__hello__ __monde__" to "hello monde",
+            "a __b__ c" to "a b c",
+            "_x_ __y__ z" to "x y z",
+            "__hello_" to "__hello_",
+            "__ test _ x __\t__" to "__ test _ x __\t__",
+        ).forEach { (input, expected) ->
+            assertEquals(expected, input.removeUnderscoreBoldAndItalics())
+        }
+    }
+
+    @Test
     fun testStripHtml() {
         mapOf(
             "< This is a test" to "< This is a test",
@@ -70,6 +84,12 @@ class AnchorsGeneratorTest {
                 "check-out-this-awesome-repo-derlin",
                 "check-out-this-awesome-repo--derlin",
                 "check-out-this-awesome-repo-❣-derlin"
+            ),
+            listOf(
+                "Some __bold__ ? and _i_ t __alic__ _",
+                "some-bold-and-i-t-alic-_",
+                "some-bold--and-i-t-alic-_",
+                "some-bold-and-i-t-alic-",
             )
         ).forEach { (input, gitlab, github, devto) ->
             assertEquals(gitlab, DEFAULT.toAnchor(input))


### PR DESCRIPTION
When a title contains bold and italics using underscores (vs wildcards), those are stripped when generating the anchors.

This commit adds this logic so that "__hello__" properly maps to the anchor "hello".

Closes: #23