### PR TITLE
feat: support GitLab 17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ You can now execute it in the CMD. Note that it may take a while to launch, but 
 
 ## TOC flavors (profiles)
 
-This tool supports some profiles out-of-the-box: GitLab, GitHub, and dev.to. The Generic profile
-is perfect for platforms such as BitBucket Server which do not generate anchor links on their own.
+This tool supports some profiles out-of-the-box: GitLab, GitLab 17 (version 17.0 and above), GitHub, and dev.to.
+The Generic profile is perfect for platforms such as BitBucket Server which do not generate anchor links on their own.
 Simply choose your flavor using the profile option (`-p`/`--profile`).
 
 It is however highly customizable, and the options can also fit many other platforms.
@@ -172,6 +172,7 @@ Here is a breakdown of the options (that differ from the defaults) to use for ea
 
 * *Generic* → generate anchors (e.g. BitBucket Server)
 * *GitLab* → concat spaces, do not generate anchors
+* *GitLab 17* → do not concat spaces, do not generate anchors
 * *GitHub* → do not concat spaces, do not generate anchors
 * *dev.to* → concat spaces, do not generate anchors, comment style = liquid, anchors algorithm = DEVTO
 * *hashnode* → concat spaces, anchors prefix = "heading-", anchors algorithm = HASHNODE

--- a/src/commonMain/kotlin/ch/derlin/bitdowntoc/BitOptions.kt
+++ b/src/commonMain/kotlin/ch/derlin/bitdowntoc/BitOptions.kt
@@ -8,9 +8,10 @@ internal const val BITDOWNTOC_URL = "https://github.com/derlin/bitdowntoc"
 enum class BitProfiles(val displayName: String) {
     GENERIC("Generic"),
     GITHUB("GitHub"),
+    GITLAB17("Gitlab 17+"),
     GITLAB("Gitlab"),
-    DEVTO("dev.to"),
-    HASHNODE("hashnode");
+    HASHNODE("hashnode"),
+    DEVTO("dev.to");
 
     companion object {
         fun BitGenerator.Params.defaults() =
@@ -26,7 +27,7 @@ enum class BitProfiles(val displayName: String) {
     fun applyToParams(params: BitGenerator.Params): BitGenerator.Params = when (this) {
         GENERIC -> params.defaults().copy(generateAnchors = true)
         GITLAB -> params.defaults()
-        GITHUB -> params.defaults().copy(concatSpaces = false)
+        GITLAB17, GITHUB -> params.defaults().copy(concatSpaces = false)
         DEVTO -> params.defaults().copy(anchorAlgorithm = AnchorAlgorithm.DEVTO, commentStyle = LIQUID)
         HASHNODE -> params.defaults()
             .copy(anchorAlgorithm = AnchorAlgorithm.HASHNODE, anchorsPrefix = "heading-")
@@ -51,7 +52,7 @@ enum class BitProfiles(val displayName: String) {
         return when (this) {
             GENERIC -> optionsList(anchors = true)
             GITLAB -> optionsList()
-            GITHUB -> optionsList(concatSpaces = false)
+            GITLAB17, GITHUB -> optionsList(concatSpaces = false)
             DEVTO -> optionsList(anchorAlgorithm = AnchorAlgorithm.DEVTO, commentStyle = LIQUID)
             HASHNODE -> optionsList(
                 anchorAlgorithm = AnchorAlgorithm.HASHNODE,

--- a/src/jsMain/resources/index.html
+++ b/src/jsMain/resources/index.html
@@ -116,6 +116,7 @@
         <ul>
             <li><span class="hl">Generic</span> → generate anchors (.e.g <span class="hl">BitBucket Server</span></li>
             <li><span class="hl">GitLab</span> → concat spaces, do not generate anchors</li>
+            <li><span class="hl">GitLab 17</span> → do not concat spaces, do not generate anchors</li>
             <li><span class="hl">GitHub</span> → do not concat spaces, do not generate anchors</li>
             <li><span class="hl">dev.to</span> → concat spaces, do not generate anchors, use
                 <a href="https://developers.forem.com/frontend/liquid-tags">liquid tags</a> for comments


### PR DESCRIPTION
Gitlab 17 changed its anchor generation algorithm to fit the industry standards. It will now behave like GitHub:

> the autogenerated anchor is created with fewer dash (-) characters than
> many users expect. For example, with a heading with ## Step - 1, most
> other Markdown tools and linters would expect #step---1. But GitLab
> generates an anchor of #step-1, with consecutive dashes compressed down
> to one.
> In GitLab 17.0, we will align our autogenerated anchors to the industry
> standard by no longer stripping consecutive dashes.

GitLab 17.0 is coming on May 16. This PR adds a new `GitLab17` profile that matches this change.

Closes #32 