### PR TITLE
feat: add hashnode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@
 
 BitDownToc adds a table of contents (TOC) to your Markdown files, either online or from the command line.
 It supports **Gitlab** and **GitHub** styles, and can generate anchors to comply with **Bitbucket Server**
-(and its lack of proper markdown support using the generic profile), **https://dev.to** and more.
+(and its lack of proper markdown support using the generic profile), **[dev.to](https://dev.to)**,
+**[hashnode](https://hashnode.com)**, and more!
 
 Thanks to small comments (in HTML or liquid tags), it can also detect previously generated TOC,
 so you can run it every time you change your README without worries. In other words, it is **idempotent** 🤩.
@@ -88,6 +89,8 @@ bitdowntoc -p github readme.md --inplace # or
 bitdowntoc --no-anchors --no-concat-spaces readme.md --inplace
 # DevTo
 bitdowntoc -p devto
+# Hashnode
+bitdowntoc -p hashnode
 ```
 NOTE: if you are downloaded the jar, replace `bitdowntoc` above with `java -jar bitdowntoc-jvm-*.jar`.
 If you installed the native executable manually, replace `bitdowntoc` above with `<path/to/executable>`.
@@ -129,7 +132,7 @@ Options:
                                    (false) or not (true). (default: false)
   --max-level INT                  Maximum heading level to include to the toc
                                    (< 1 means no limit). (default: '-1')
-  -p, --profile [GENERIC|GITHUB|GITLAB|DEVTO]
+  -p, --profile [GENERIC|GITHUB|GITLAB|DEVTO|HASHNODE]
                                    Load default options for a specific site
   -i, --inplace                    Overwrite input file
   -o, --output-file PATH           Write the output to a file instead of the
@@ -177,10 +180,10 @@ Here is a breakdown of the options (that differ from the defaults) to use for ea
 * *GitLab* → concat spaces, do not generate anchors
 * *GitHub* → do not concat spaces, do not generate anchors
 * *dev.to* → concat spaces, do not generate anchors, comment style = liquid, anchors algorithm = DEVTO
+* *hashnode* → concat spaces, anchors prefix = "heading-", anchors algorithm = HASHNODE
 
 ### Other platforms
 
-* *hashnode* → anchors prefix = `heading-`
 * *BitBucket.org* (supports the `[TOC]` directly) → anchors algorithm = DEVTO, anchors prefix = `markdown-header-`
   ❗ will break if you use code in your headings (backticks) - open an issue if you want support :)
 

--- a/src/commonMain/kotlin/ch/derlin/bitdowntoc/BitOptions.kt
+++ b/src/commonMain/kotlin/ch/derlin/bitdowntoc/BitOptions.kt
@@ -9,11 +9,18 @@ enum class BitProfiles(val displayName: String) {
     GENERIC("Generic"),
     GITHUB("GitHub"),
     GITLAB("Gitlab"),
-    DEVTO("dev.to");
+    DEVTO("dev.to"),
+    HASHNODE("Hashnode");
 
     companion object {
         fun BitGenerator.Params.defaults() =
-            copy(generateAnchors = false, concatSpaces = true, anchorAlgorithm = AnchorAlgorithm.DEFAULT, commentStyle = HTML)
+            copy(
+                generateAnchors = false,
+                concatSpaces = true,
+                anchorAlgorithm = AnchorAlgorithm.DEFAULT,
+                commentStyle = HTML,
+                anchorsPrefix = ""
+            )
     }
 
     fun applyToParams(params: BitGenerator.Params): BitGenerator.Params = when (this) {
@@ -21,6 +28,8 @@ enum class BitProfiles(val displayName: String) {
         GITLAB -> params.defaults()
         GITHUB -> params.defaults().copy(concatSpaces = false)
         DEVTO -> params.defaults().copy(anchorAlgorithm = AnchorAlgorithm.DEVTO, commentStyle = LIQUID)
+        HASHNODE -> params.defaults()
+            .copy(anchorAlgorithm = AnchorAlgorithm.HASHNODE, anchorsPrefix = "heading-")
     }
 
     fun overriddenBitOptions(): List<BitOption<*>> {
@@ -29,12 +38,14 @@ enum class BitProfiles(val displayName: String) {
             concatSpaces: Boolean = true,
             anchorAlgorithm: AnchorAlgorithm = AnchorAlgorithm.DEFAULT,
             commentStyle: CommentStyle = HTML,
+            anchorsPrefix: String = "",
         ) =
             listOf(
                 BitOptions.generateAnchors.copy(default = anchors),
                 BitOptions.concatSpaces.copy(default = concatSpaces),
                 BitOptions.anchorAlgorithm.copy(default = anchorAlgorithm),
-                BitOptions.commentStyle.copy(default = commentStyle)
+                BitOptions.commentStyle.copy(default = commentStyle),
+                BitOptions.anchorsPrefix.copy(default = anchorsPrefix)
             )
 
         return when (this) {
@@ -42,6 +53,11 @@ enum class BitProfiles(val displayName: String) {
             GITLAB -> optionsList()
             GITHUB -> optionsList(concatSpaces = false)
             DEVTO -> optionsList(anchorAlgorithm = AnchorAlgorithm.DEVTO, commentStyle = LIQUID)
+            HASHNODE -> optionsList(
+                anchorAlgorithm = AnchorAlgorithm.HASHNODE,
+                concatSpaces = true,
+                anchorsPrefix = "heading-"
+            )
         }
     }
 }

--- a/src/commonTest/kotlin/ch.derlin.bitdowntoc/AnchorsGeneratorTest.kt
+++ b/src/commonTest/kotlin/ch.derlin.bitdowntoc/AnchorsGeneratorTest.kt
@@ -2,6 +2,7 @@ package ch.derlin.bitdowntoc
 
 import ch.derlin.bitdowntoc.AnchorAlgorithm.DEFAULT
 import ch.derlin.bitdowntoc.AnchorAlgorithm.DEVTO
+import ch.derlin.bitdowntoc.AnchorAlgorithm.HASHNODE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -54,47 +55,56 @@ class AnchorsGeneratorTest {
                 "table-of-content-code-",
                 "table-of-content--code------",
                 "tableof-content-raw-code-endraw-\uD83D\uDD4A-☮-✌",
+                "table-of-content-code"
             ),
             listOf(
                 "Check out [bitdowntoc](https://bitdowntoc.ch),   It is *awesome*!",
                 "check-out-bitdowntoc-it-is-awesome",
                 "check-out-bitdowntoc---it-is-awesome",
                 "check-out-bitdowntoc-it-is-awesome",
+                "check-out-bitdowntochttpsbitdowntocch-it-is-awesome",
             ),
             listOf(
                 "'Hello' means ˮBonjourˮ en français héhé â",
                 "hello-means-ˮbonjourˮ-en-français-héhé-â",
                 "hello-means-ˮbonjourˮ-en-français-héhé-â",
-                "hello-means-ˮbonjourˮ-en-français-héhé-â"
+                "hello-means-ˮbonjourˮ-en-français-héhé-â",
+                "hello-means-bonjour-en-francais-hehe-a",
             ),
             listOf(
                 "' ' ʻ ՚ Ꞌ ꞌ ′ ″ ‴ 〃 \" ˮ",
                 "-ʻ-ꞌ-ꞌ-ˮ",
                 "--ʻ--ꞌ-ꞌ------ˮ",
-                "-ʻ-ꞌ-ꞌ-ˮ"
+                "-ʻ-ꞌ-ꞌ-ˮ",
+                "" // NOTE: hashnode will generate random anchors when empty
             ),
             listOf(
                 "`<hello href=\"test-hello\">` <hello> `&%£`",
                 "hello-hreftest-hello-",
                 "hello-hreftest-hello--",
-                "-raw-lthello-hreftesthellogt-endraw-raw-amp£-endraw-"
+                "-raw-lthello-hreftesthellogt-endraw-raw-amp£-endraw-",
+                "amp"
             ),
             listOf(
                 "Check out [this AWESOME REPO ❣](https://github.com/derlin/bitdowntoc) (@derlin)  ",
                 "check-out-this-awesome-repo-derlin",
                 "check-out-this-awesome-repo--derlin",
-                "check-out-this-awesome-repo-❣-derlin"
+                "check-out-this-awesome-repo-❣-derlin",
+                "check-out-this-awesome-repo-httpsgithubcomderlinbitdowntoc-derlin"
             ),
             listOf(
                 "Some __bold__ ? and _i_ t __alic__ _",
                 "some-bold-and-i-t-alic-_",
                 "some-bold--and-i-t-alic-_",
                 "some-bold-and-i-t-alic-",
+                "some-bold-and-i-t-alic"
             )
-        ).forEach { (input, gitlab, github, devto) ->
+        ).forEach { (input, gitlab, github, devto, hashnode) ->
             assertEquals(gitlab, DEFAULT.toAnchor(input))
             assertEquals(github, DEFAULT.toAnchor(input, concatSpaces = false))
             assertEquals(devto, DEVTO.toAnchor(input))
+            // the anchor prefix "heading-" is added after!.
+            assertEquals(hashnode, HASHNODE.toAnchor(input))
         }
     }
 }

--- a/src/jsMain/kotlin/impl.kt
+++ b/src/jsMain/kotlin/impl.kt
@@ -1,0 +1,6 @@
+package ch.derlin.bitdowntoc
+
+actual fun String.removeDiacritics(): String =
+    this.normalize().replace("\\p{Diacritic}", "", ignoreCase = true)
+
+fun String.normalize(): String = asDynamic().normalize("NFD")

--- a/src/jsMain/resources/index.html
+++ b/src/jsMain/resources/index.html
@@ -123,8 +123,7 @@ placeholder to control where the TOC will appear
             <li><span class="hl">dev.to</span> → concat spaces, do not generate anchors, use
                 <a href="https://developers.forem.com/frontend/liquid-tags">liquid tags</a> for comments
             </li>
-            <li>(<span class="hl">hashnode</span>) → concat spaces, do not generate anchors, anchors prefix
-                set to "heading-"
+            <li><span class="hl">hashnode</span> → concat spaces, do not generate anchors, anchors prefix "heading-"
             </li>
         </ul>
         <p class="small">

--- a/src/jvmMain/kotlin/ch/derlin/bitdowntoc/impl.kt
+++ b/src/jvmMain/kotlin/ch/derlin/bitdowntoc/impl.kt
@@ -1,0 +1,7 @@
+package ch.derlin.bitdowntoc
+
+import java.text.Normalizer
+
+actual fun String.removeDiacritics(): String =
+    Normalizer.normalize(this, Normalizer.Form.NFD)
+        .replace("\\p{Mn}+".toRegex(), "")


### PR DESCRIPTION
Hashnode is using a very strange algorithm, completely different from the other platform (and somewhat easier).

This commit adds a new profile, hashnode, to the list of supported builtins!

Closes #21 