### PR TITLE
Honor dark theme preferences on the web

### DIFF
--- a/src/jsMain/css/index.css
+++ b/src/jsMain/css/index.css
@@ -205,6 +205,7 @@ textarea {
   font-size: .9rem;
   display: block;
   position: absolute;
+  height: 100%;
   padding: 7px;
   width: 100%;
   top: 30px;
@@ -214,6 +215,7 @@ textarea {
   outline: none !important;
   border-radius: 0 0 0 20px;
   color: var(--text-color);
+  resize: vertical;
 }
 
 textarea:focus {

--- a/src/jsMain/kotlin/main.kt
+++ b/src/jsMain/kotlin/main.kt
@@ -73,11 +73,14 @@ class Modal(val modal: HTMLElement, showBtn: HTMLElement, closeBtn: HTMLElement)
 
 class ThemeSwitcher(val toggleButton: HTMLElement) {
     companion object {
+        private const val THEME_KEY = "theme"
         private const val DARK_CLS = "dark"
     }
 
     private val html: HTMLElement = document.getElementsByTagName("html")[0] as HTMLElement
-    private var isDark: Boolean = localStorage.getItem(DARK_CLS) != null
+    // NOTE: a script in HTML head is added to avoid flashes on load
+    private var isDark: Boolean = localStorage.getItem(THEME_KEY)?.let { it == DARK_CLS }
+        ?: window.matchMedia("(prefers-color-scheme: dark)").matches
 
     init {
         applyTheme()
@@ -86,17 +89,16 @@ class ThemeSwitcher(val toggleButton: HTMLElement) {
 
     fun toggleTheme() {
         isDark = !isDark
+        localStorage.setItem(THEME_KEY, if (isDark) DARK_CLS else "light")
         applyTheme()
     }
 
     private fun applyTheme() {
         if (isDark) {
             console.log("applying dark theme")
-            localStorage.setItem(DARK_CLS, "true")
             html.classList.add(DARK_CLS)
         } else {
             console.log("applying light theme")
-            localStorage.removeItem(DARK_CLS)
             html.classList.remove(DARK_CLS)
         }
     }

--- a/src/jsMain/resources/index.html
+++ b/src/jsMain/resources/index.html
@@ -29,7 +29,9 @@
     <!-- css -->
     <link rel="stylesheet" type="text/css" href="index.min.css"/>
     <script type="text/javascript">
-    if(localStorage.getItem("dark")){ // avoid flashes onload using dark theme
+    // avoid flashes onload using dark theme
+    const storagePref = localStorage.getItem("theme");
+    if((!storagePref && window.matchMedia("(prefers-color-scheme: dark)").matches) || storagePref === "dark"){
       document.getElementsByTagName('html')[0].classList.add("dark");
     }
     </script>


### PR DESCRIPTION
Fix some weird textarea behavior and honor the dark theme preference of the system if the user didn't toggle the theme manually.

Closes #38 