### PR TITLE
feat: add indent-spaces option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Usage: bitdowntoc [<options>] [<path>]
 Options:
   --version                                Show version and exit
   --indent-chars=<text>                    Characters used for indenting the toc (default: '-*+')
+  --indent-spaces=<int>                    Number of spaces per indentation level for indenting the toc (default: 3)
   --concat-spaces / --no-concat-spaces     Whether to trim heading spaces in generated links (foo-bar) or not
                                            (foo----bar) (default: true)
   --anchors-prefix=<text>                  Prefix added to all anchors and TOC links (e.g. 'heading-') (default: '')

--- a/src/commonMain/kotlin/ch/derlin/bitdowntoc/BitGenerator.kt
+++ b/src/commonMain/kotlin/ch/derlin/bitdowntoc/BitGenerator.kt
@@ -11,6 +11,7 @@ object BitGenerator {
 
     data class Params(
         val indentChars: String = BitOptions.indentChars.default,
+        val indentSpaces: Int = BitOptions.indentSpaces.default,
         val maxLevel: Int = BitOptions.maxLevel.default,
         val generateAnchors: Boolean = BitOptions.generateAnchors.default,
         val anchorAlgorithm: AnchorAlgorithm = BitOptions.anchorAlgorithm.default,
@@ -74,7 +75,7 @@ object BitGenerator {
             }
         }
 
-        val tocString = toc.generateToc(params.indentChars, params.trimTocIndent).let {
+        val tocString = toc.generateToc(params.indentChars, params.indentSpaces, params.trimTocIndent).let {
             if (params.oneShot) it else commenter.wrapToc(it).asText()
         }
 

--- a/src/commonMain/kotlin/ch/derlin/bitdowntoc/BitOptions.kt
+++ b/src/commonMain/kotlin/ch/derlin/bitdowntoc/BitOptions.kt
@@ -70,6 +70,10 @@ object BitOptions {
         "indent-chars", "indent characters", "-*+",
         "Characters used for indenting the toc"
     )
+    val indentSpaces = BitOption(
+        "indent-spaces", "indent spaces", 3,
+        "Number of spaces per indentation level for indenting the toc"
+    )
     val generateAnchors = BitOption(
         "anchors", "generate anchors", true,
         "Whether to generate anchors below headings (e.g. BitBucket Server)"
@@ -107,6 +111,7 @@ object BitOptions {
 
     val list: Array<BitOption<*>> = arrayOf(
         indentChars,
+        indentSpaces,
         generateAnchors,
         anchorAlgorithm,
         anchorsPrefix,

--- a/src/commonMain/kotlin/ch/derlin/bitdowntoc/Toc.kt
+++ b/src/commonMain/kotlin/ch/derlin/bitdowntoc/Toc.kt
@@ -35,12 +35,12 @@ class Toc(
         }
     }
 
-    fun generateToc(indentCharacters: String, trimTocIndent: Boolean): String {
+    fun generateToc(indentCharacters: String, indentSpaces: Int, trimTocIndent: Boolean): String {
         if (this.entries.isEmpty()) return ""
         val minIndent = if (trimTocIndent) entries.minOf { it.indent } else 0
         return entries.joinToString("\n") { (indent, text, link) ->
             (indent - minIndent).let {
-                " ".repeat(it * 3) + "${indentCharacters[it % indentCharacters.length]} [$text](#$link)"
+                " ".repeat(it * indentSpaces) + "${indentCharacters[it % indentCharacters.length]} [$text](#$link)"
             }
         }
     }

--- a/src/commonTest/kotlin/ch.derlin.bitdowntoc/GenerateTest.kt
+++ b/src/commonTest/kotlin/ch.derlin.bitdowntoc/GenerateTest.kt
@@ -187,6 +187,121 @@ class GenerateTest {
         )
     }
 
+    @Test
+    fun testIndentCharacters() {
+        val input = """
+        # Some readme
+        
+        [TOC]
+        
+        ## heading
+        
+        this is a test
+        ```code
+        ## comment, not header
+        ```
+        
+        ### subheading
+        
+        test
+        
+        ## heading
+        duplicate name
+        """.trimIndent()
+
+        assertEquals(
+            """
+            # Some readme
+            
+            <!-- TOC start (generated with $BITDOWNTOC_URL) -->
+            
+            + [heading](#heading)
+               + [subheading](#subheading)
+            + [heading](#heading-1)
+            
+            <!-- TOC end -->
+            
+            <!-- TOC --><a name="heading"></a>
+            ## heading
+            
+            this is a test
+            ```code
+            ## comment, not header
+            ```
+            
+            <!-- TOC --><a name="subheading"></a>
+            ### subheading
+            
+            test
+            
+            <!-- TOC --><a name="heading-1"></a>
+            ## heading
+            duplicate name
+            """.trimIndent(),
+            BitGenerator.generate(input, Params(indentChars = "+"))
+        )
+    }
+
+    @Test
+    fun testIndentSpaces() {
+        val input = """
+        # Some readme
+        
+        [TOC]
+        
+        ## heading
+        
+        this is a test
+        ```code
+        ## comment, not header
+        ```
+        
+        ### subheading
+        
+        #### nested subheading
+        
+        test
+        
+        ## heading
+        duplicate name
+        """.trimIndent()
+
+        assertEquals(
+            """
+            # Some readme
+            
+            <!-- TOC start (generated with $BITDOWNTOC_URL) -->
+            
+            - [heading](#heading)
+                 * [subheading](#subheading)
+                      + [nested subheading](#nested-subheading)
+            - [heading](#heading-1)
+            
+            <!-- TOC end -->
+            
+            <!-- TOC --><a name="heading"></a>
+            ## heading
+            
+            this is a test
+            ```code
+            ## comment, not header
+            ```
+            
+            <!-- TOC --><a name="subheading"></a>
+            ### subheading
+            
+            <!-- TOC --><a name="nested-subheading"></a>
+            #### nested subheading
+            
+            test
+            
+            <!-- TOC --><a name="heading-1"></a>
+            ## heading
+            duplicate name
+            """.trimIndent(),
+            BitGenerator.generate(input, Params(indentSpaces = 5))
+        )
+    }
 
     @Test
     fun testNoText() {

--- a/src/jsMain/kotlin/toc.kt
+++ b/src/jsMain/kotlin/toc.kt
@@ -121,6 +121,7 @@ fun generate(text: String) =
 
 fun getParams() = BitGenerator.Params(
     indentChars = BitOptions.indentChars.getValue(),
+    indentSpaces = BitOptions.indentSpaces.getValue(),
     generateAnchors = BitOptions.generateAnchors.getValue(),
     anchorsPrefix = BitOptions.anchorsPrefix.getValue(),
     commentStyle = BitOptions.commentStyle.getValue(),

--- a/src/jvmMain/kotlin/ch/derlin/bitdowntoc/main.kt
+++ b/src/jvmMain/kotlin/ch/derlin/bitdowntoc/main.kt
@@ -43,6 +43,7 @@ class Cli(
     private val path: String by argument(help = "Markdown file, or '-' to read from stdin").default("")
 
     private val indentChars: String by BitOptions.indentChars.cliOption()
+    private val indentSpaces: Int by BitOptions.indentSpaces.cliOptionInt()
     private val concatSpaces: Boolean by BitOptions.concatSpaces.cliOptionBool()
     private val anchorsPrefix: String by BitOptions.anchorsPrefix.cliOption()
     private val generateAnchors: Boolean by BitOptions.generateAnchors.cliOptionBool()
@@ -93,6 +94,7 @@ class Cli(
         val output = if (inplace) inputFile else outputFile?.toFile()
         val params = BitGenerator.Params(
             indentChars = indentChars,
+            indentSpaces = indentSpaces,
             generateAnchors = generateAnchors,
             anchorAlgorithm = anchorAlgorithm,
             anchorsPrefix = anchorsPrefix,


### PR DESCRIPTION
Add "--indent-spaces" integer option to specify the number of spaces to add in the TOC per indentation level. Defaults to the current width of 3 spaces.

Add test cases for the new "indentSpaces" parameter as well as the existing "indentCharacters" parameter.

---

This is a great tool! For my use case, I had to use 2 spaces per indent in the TOC. This seems like the best way to do it. I also added a bonus test case for the flag this one is modeled on. Validated passing tests, and the option shows and works in the browser.