### PR TITLE
fix: properly handle duplicates above the TOC placeholder

### DIFF
--- a/src/commonMain/kotlin/ch/derlin/bitdowntoc/BitGenerator.kt
+++ b/src/commonMain/kotlin/ch/derlin/bitdowntoc/BitGenerator.kt
@@ -57,6 +57,8 @@ object BitGenerator {
                 tocMarker == line -> {
                     break@loop
                 }
+
+                else -> line.parseHeader(toc, ignore = true)
             }
         }
 
@@ -83,11 +85,11 @@ object BitGenerator {
     }
 
 
-    private fun String.parseHeader(toc: Toc) =
+    private fun String.parseHeader(toc: Toc, ignore: Boolean = false) =
         headerRegex.matchEntire(this)?.let {
             val indent = it.groupValues[1].length
             val title = it.groupValues[2]
-            toc.addTocEntry(indent, title)
+            toc.addTocEntry(if (ignore) -1 else indent, title)
         }
 
     private fun Iterable<String>.hasToc(commenter: Commenter): Boolean =

--- a/src/commonMain/kotlin/ch/derlin/bitdowntoc/Toc.kt
+++ b/src/commonMain/kotlin/ch/derlin/bitdowntoc/Toc.kt
@@ -20,14 +20,17 @@ class Toc(
         levelBoundaries.let { (min, max) -> indent in min..max }
 
     fun addTocEntry(indent: Int, title: String): TocEntry? {
+        // always keep track of the links, to properly handle duplicates even if skipped
+        var link = anchorsPrefix + anchorsGenerator.toAnchor(title, concatSpaces = concatSpaces)
+        val linkCount = links.getOrElse(link) { 0 }
+        links[link] = linkCount + 1
+
         return if (!shouldBeAdded(indent)) null else {
-            var link = anchorsPrefix + anchorsGenerator.toAnchor(title, concatSpaces = concatSpaces)
             // add numbers at the end of the link if it is a duplicate
-            val linkCount = links[link] ?: 0
-            links[link] = linkCount + 1
             if (linkCount > 0) {
                 link += "-$linkCount"
             }
+
             // create the entry
             val entry = TocEntry(indent - 1, anchorsGenerator.escapeTitle(title), link)
             entries += entry

--- a/src/commonTest/kotlin/ch.derlin.bitdowntoc/GenerateTest.kt
+++ b/src/commonTest/kotlin/ch.derlin.bitdowntoc/GenerateTest.kt
@@ -28,7 +28,7 @@ class GenerateTest {
     @Test
     fun testBasicGeneration() {
         val input = """
-        # Some readme
+        # Title
         
         [TOC]
         
@@ -43,19 +43,19 @@ class GenerateTest {
         
         test
         
-        ## heading
+        ## title
         duplicate name
         """.trimIndent()
 
         assertEquals(
             """
-            # Some readme
+            # Title
             
             <!-- TOC start (generated with $BITDOWNTOC_URL) -->
             
             - [heading](#heading)
                * [subheading](#subheading)
-            - [heading](#heading-1)
+            - [title](#title-1)
             
             <!-- TOC end -->
             
@@ -72,8 +72,8 @@ class GenerateTest {
             
             test
             
-            <!-- TOC --><a name="heading-1"></a>
-            ## heading
+            <!-- TOC --><a name="title-1"></a>
+            ## title
             duplicate name
             """.trimIndent(),
             BitGenerator.generate(input)
@@ -142,7 +142,7 @@ class GenerateTest {
     fun testGenerateWithoutAnchors() {
 
         val input = """
-        # Some readme
+        # HEADING
         
         [TOC]
         
@@ -161,13 +161,13 @@ class GenerateTest {
 
         assertEquals(
             """
-            # Some readme
+            # HEADING
             
             <!-- TOC start (generated with $BITDOWNTOC_URL) -->
             
-            - [heading](#heading)
-               * [subheading](#subheading)
             - [heading](#heading-1)
+               * [subheading](#subheading)
+            - [heading](#heading-2)
             
             <!-- TOC end -->
             

--- a/src/commonTest/kotlin/ch.derlin.bitdowntoc/TocTest.kt
+++ b/src/commonTest/kotlin/ch.derlin.bitdowntoc/TocTest.kt
@@ -10,16 +10,22 @@ class TocTest {
 
     @Test
     fun testDuplicateLinkGeneration() {
-        val headingToLinks = mutableListOf<Pair<String, String>>()
-        val toc = Toc()
+        val toc = Toc(levelBoundaries = 1 to 3)
 
-        repeat(3) {
-            toc.addTocEntry(1, "Heading")
-            headingToLinks += Pair("Heading", "heading" + (if (it > 0) "-$it" else ""))
-        }
+        toc.addTocEntry(1, "Heading")
+        toc.addTocEntry(4, "Heading")
+        toc.addTocEntry(2, "Heading")
+        toc.addTocEntry(5, "Heading")
+        toc.addTocEntry(6, "Heading")
+        toc.addTocEntry(3, "Heading")
+
         assertEquals(3, toc.entries.size, "3 entries should be registered")
         assertEquals(1, toc.links.size, "all entries should have the same link")
-        assertEquals(headingToLinks, toc.entries.map { Pair(it.title, it.link) })
+        assertEquals(mapOf(
+            "Heading" to "heading",
+            "Heading" to "heading-2",
+            "Heading" to "heading-5"
+        ), toc.entries.associate { Pair(it.title, it.link) })
     }
 
     @Test


### PR DESCRIPTION
Heading above the `[TOC]` were so far discarded, but this messes up the numbering of duplicate headings.

This commit fixes it, by also registering headings above the placeholder.

Closes #45 