### PR TITLE
feat: properly raise error on missing toc end

### DIFF
--- a/src/commonMain/kotlin/ch/derlin/bitdowntoc/BitGenerator.kt
+++ b/src/commonMain/kotlin/ch/derlin/bitdowntoc/BitGenerator.kt
@@ -96,9 +96,12 @@ object BitGenerator {
         this.map { it.trim() }.any { it == tocMarker || commenter.isTocStart(it) }
 
     private fun MutableListIterator<String>.consumeToc(commenter: Commenter) {
-        do {
+        this.remove() // remove toc start
+        while (this.hasNext()) {
+            if (commenter.isTocEnd(this.next())) return
             this.remove()
-        } while (this.hasNext() && !commenter.isTocEnd(this.next()))
+        }
+        throw MissingTocEndException()
     }
 
     private fun String.isCodeStart(codeMarker: String) =

--- a/src/commonMain/kotlin/ch/derlin/bitdowntoc/exceptions.kt
+++ b/src/commonMain/kotlin/ch/derlin/bitdowntoc/exceptions.kt
@@ -1,0 +1,5 @@
+package ch.derlin.bitdowntoc
+
+open class BitException(override val message: String) : RuntimeException(message)
+
+class MissingTocEndException : BitException("The document has a TOC start, but is missing a TOC end.")

--- a/src/commonTest/kotlin/ch.derlin.bitdowntoc/GenerateTest.kt
+++ b/src/commonTest/kotlin/ch.derlin.bitdowntoc/GenerateTest.kt
@@ -4,6 +4,7 @@ import ch.derlin.bitdowntoc.BitGenerator.Params
 import ch.derlin.bitdowntoc.CommentStyle.LIQUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class GenerateTest {
 
@@ -482,6 +483,26 @@ class GenerateTest {
             input,
             BitGenerator.generate(input, Params(generateAnchors = false))
         )
+    }
+
+    @Test
+    fun testMissingTocEnd() {
+        val input = """
+            <!-- TOC start (generated with $BITDOWNTOC_URL) -->
+            
+            - [h1](#h1)
+            
+            # h1
+            Use [TOC] to control the toc:
+            ```
+            [TOC]
+            ```
+            """.trimIndent()
+
+        assertFailsWith<MissingTocEndException>(message = "The document has a TOC start, but is missing a TOC end") {
+            BitGenerator.generate(input, Params(generateAnchors = false))
+
+        }
     }
 
 

--- a/src/jsMain/kotlin/toc.kt
+++ b/src/jsMain/kotlin/toc.kt
@@ -116,8 +116,13 @@ fun loadOptions() {
     console.log("options saved")
 }
 
-fun generate(text: String) =
+fun generate(text: String): String = try {
     BitGenerator.generate(text, getParams())
+} catch (e: BitException) {
+    "\nError!\n${e.message}"
+}.also {
+    console.log("returned $it")
+}
 
 fun getParams() = BitGenerator.Params(
     indentChars = BitOptions.indentChars.getValue(),

--- a/src/jvmMain/kotlin/ch/derlin/bitdowntoc/main.kt
+++ b/src/jvmMain/kotlin/ch/derlin/bitdowntoc/main.kt
@@ -108,8 +108,13 @@ class Cli(
             profile?.applyToParams(it) ?: it
         }
 
-        BitGenerator.generate(inputText, params).let {
-            (output?.writeText(it)) ?: echo(it)
+        try {
+
+            BitGenerator.generate(inputText, params).let {
+                (output?.writeText(it)) ?: echo(it)
+            }
+        } catch (e: BitException) {
+            throw CliktError("[Error] ${e.message}")
         }
     }
 


### PR DESCRIPTION
If there is a TOC start but no TOC end, bitdowntoc now raises a proper exception instead of outputting an empty document.

Closes #49 