### PR TITLE
fix: don't break UI on long lines

### DIFF
--- a/src/jsMain/css/index.css
+++ b/src/jsMain/css/index.css
@@ -161,6 +161,7 @@ body {
     height: 100%;
     display: flex;
     flex-direction: column;
+    max-width: calc(50% - 5px);
 }
 
 .textarea {
@@ -203,6 +204,7 @@ body {
   }
   .textarea-column {
     margin-top: 20px;
+    max-width: 100%;
   }
   #options > div {
       flex: 100%;


### PR DESCRIPTION
When a very long line appears in the editor, it expands the code area and hides the other.

This commit fixes it by adding a max-width on the columns on large displays.

Closes: #63 