### PR TITLE
fix: support 4 backticks

### DIFF
--- a/src/commonTest/kotlin/ch.derlin.bitdowntoc/GenerateTest.kt
+++ b/src/commonTest/kotlin/ch.derlin.bitdowntoc/GenerateTest.kt
@@ -137,6 +137,31 @@ class GenerateTest {
                   ```
             """.trimIndent()
         )
+
+        assertDoesNotChangeToc(
+            """
+            ````
+            # Markdown
+            - ```
+              code
+              ```
+
+            ~~~
+            code
+            ~~~
+            ````
+            """.trimIndent()
+        )
+
+        assertFailsWith<AssertionError> {
+            assertDoesNotChangeToc(
+                """
+            ````
+            code
+            ```
+            """.trimIndent()
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
Make it possible to use more than 3 backticks (or ~) for code markers. This change also ensures it is possible to use a code block with 4 markers, which itself contains code blocks with 3 markers.

Basically, it remembers what the start was, and considers the code block end only when the same marker is found.

Closes #65 