### PR TITLE
feat(web): improve options by showing inputs on the right

### DIFF
--- a/src/jsMain/css/index.css
+++ b/src/jsMain/css/index.css
@@ -176,6 +176,10 @@ body {
   border-radius: 0 0 0 20px;
 }
 
+#select-profile {
+  margin-right: 1em;
+}
+
 #options {
     display: flex;
     flex-wrap: wrap;
@@ -406,23 +410,24 @@ input[type=number]::-webkit-outer-spin-button {
 }
 
 /* Base for label styling */
-[type="checkbox"]:not(:checked),
-[type="checkbox"]:checked {
-  position: absolute;
-  left: 0;
-  opacity: 0.01;
+[type="checkbox"] {
+  visibility: hidden;
+  display: inline-block;
+  width: 0;
+  margin: 0;
+  padding: 0;
 }
 
-[type="checkbox"]:not(:checked)+label,
-[type="checkbox"]:checked+label {
+[type="checkbox"]:not(:checked)+span,
+[type="checkbox"]:checked+span {
   position: relative;
   padding-left: 2em;
   cursor: pointer;
 }
 
 /* checkbox aspect */
-[type="checkbox"]:not(:checked)+label:before,
-[type="checkbox"]:checked+label:before {
+[type="checkbox"]:not(:checked)+span:before,
+[type="checkbox"]:checked+span:before {
   content: '';
   position: absolute;
   left: 0;
@@ -434,7 +439,7 @@ input[type=number]::-webkit-outer-spin-button {
 }
 
 /* checked mark aspect */
-[type="checkbox"]:checked+label:after {
+[type="checkbox"]:checked+span:after {
   content: '\2715';
   /* '✕' */
   position: absolute;
@@ -445,11 +450,12 @@ input[type=number]::-webkit-outer-spin-button {
   -webkit-transition: all .2s;
   transition: all .2s;
   font-family: var(--monospace);
+  font-weight: bold;
 }
 
 /* Accessibility */
-[type="checkbox"]:checked:focus+label:before,
-[type="checkbox"]:not(:checked):focus+label:before {
+[type="checkbox"]:checked:focus+span:before,
+[type="checkbox"]:not(:checked):focus+span:before {
   /*box-shadow: inset 0 1px 3px rgba(0,0,0, .1), 0 0 0 6px rgba(203, 34, 237, .2);*/
   border-color: #444;
 }

--- a/src/jsMain/kotlin/toc.kt
+++ b/src/jsMain/kotlin/toc.kt
@@ -184,7 +184,7 @@ fun <T> BitOption<T>.setValue(value: String) = when (default) {
 
 fun BitOption<*>.toHtml(): String {
     val input = when (default) {
-        is Boolean -> """<input id ="$id" type="checkbox" ${if (default) "checked=checked" else ""} />"""
+        is Boolean -> """<input id ="$id" type="checkbox" ${if (default) "checked=checked" else ""} /><span></span>"""
         is Int -> """<input type="number" id="$id" value ="$default" step="1" min="-1" max="100"  />"""
         is String -> """<input id="$id" value ="$default" size="12" />"""
         is CommentStyle ->
@@ -201,8 +201,7 @@ fun BitOption<*>.toHtml(): String {
     }
 
     return """
-        $input
-        <label for="$id">$name</label>
+        <label for="$id">$name</label> $input
         <span class="help">$help</span>
         """.trimIndent()
 }

--- a/src/jsMain/resources/index.html
+++ b/src/jsMain/resources/index.html
@@ -76,8 +76,8 @@
     <div id="buttons-wrapper" class="flex-horizontal">
         <div id="select-profile">Preset:</div>
         <div>
-            <input id="toc-only" type="checkbox">
             <label for="toc-only">TOC only</label>
+            <input id="toc-only" type="checkbox"><span></span>
         </div>
         <button id="btn-generate" class="fill">generate</button>
         <button id="btn-copy" title="Copy the generated content to clipboard">copy</button>


### PR DESCRIPTION
Make it easier to read by aligning the inputs at the right of the labels.

Note that it required spans to be added after the input type checkbox, because some browsers (Firefox) do not allow :before and :after pseudo-elements on elements with no content (such as input). The span also needs to be opened and closed (versus `<span />`), or else safari doesn't close it at the right place.